### PR TITLE
fix: update winston-dynamic-logstash-transport to 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12181,9 +12181,9 @@
       }
     },
     "winston-dynamic-logstash-transport": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/winston-dynamic-logstash-transport/-/winston-dynamic-logstash-transport-0.0.2.tgz",
-      "integrity": "sha512-GNzAeB8DzFMHFED7AExywDlq34uJyZSBEtRSwS7yWgJhZg/W437cW7Pi+HBb5N8JuILBCpCf7aQwdPr/7X/35w==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/winston-dynamic-logstash-transport/-/winston-dynamic-logstash-transport-0.0.3.tgz",
+      "integrity": "sha512-75eSj6lzI19J3igms1SkmNS9Xve7Z7fqUMQ/0rwfUHf4hmkDuXBEtos8wQkXwo/A3O2GETYMGXh0GKMR8lSMzw==",
       "requires": {
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "serialize-error": "^7.0.1",
         "uuid": "^8.3.1",
         "winston": "^3.3.3",
-        "winston-dynamic-logstash-transport": "^0.0.2",
+        "winston-dynamic-logstash-transport": "^0.0.3",
         "winston-transport": "^4.4.0"
     },
     "devDependencies": {


### PR DESCRIPTION
fix the problem where it creates too many udp sockets that makes apps crash